### PR TITLE
utils: do not send "no more chunks" on timeouts

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -95,6 +95,8 @@ void uh_chunk_eof(struct client *cl)
 		return;
 
 	ustream_printf(cl->us, "0\r\n\r\n");
+
+	cl->request.disable_chunked = true;
 }
 
 /* blen is the size of buf; slen is the length of src.  The input-string need


### PR DESCRIPTION
When a keep-alive times out, it reuses the last request parameters. If the last finished request was using chunks, the timeout will send a spurious "no more chunks" chunk again.

This patch disables chunks in the request after it has sent a "no more chunks" chunk.

Fixes openwrt/openwrt#14460