### PR TITLE
main/file: add support for custom headers to file serving

### DIFF
--- a/file.c
+++ b/file.c
@@ -339,11 +339,15 @@ static char *uh_file_header(struct client *cl, int idx)
 static void uh_file_response_ok_hdrs(struct client *cl, struct stat *s)
 {
 	char buf[128];
+	struct extra_header *eh;
 
 	if (s) {
 		ustream_printf(cl->us, "ETag: %s\r\n", uh_file_mktag(s, buf, sizeof(buf)));
 		ustream_printf(cl->us, "Last-Modified: %s\r\n",
 			       uh_file_unix2date(s->st_mtime, buf, sizeof(buf)));
+	}
+	list_for_each_entry(eh, &conf.extra_header, list) {
+		ustream_printf(cl->us, "%s\r\n", eh->header);
 	}
 	ustream_printf(cl->us, "Date: %s\r\n",
 		       uh_file_unix2date(time(NULL), buf, sizeof(buf)));

--- a/uhttpd.h
+++ b/uhttpd.h
@@ -62,6 +62,11 @@ struct lua_prefix {
 	void *ctx;
 };
 
+struct extra_header {
+	struct list_head list;
+	const char *header;
+};
+
 #ifdef HAVE_UCODE
 struct ucode_prefix {
 	struct list_head list;
@@ -98,6 +103,7 @@ struct config {
 	int events_retry;
 	struct list_head cgi_alias;
 	struct list_head lua_prefix;
+	struct list_head extra_header;
 #ifdef HAVE_UCODE
 	struct list_head ucode_prefix;
 #endif


### PR DESCRIPTION
This allows us to set 'Cache-Control: no-cache', which makes it possible to develop LuCI JS without resorting to disabling the cache in the browser dev tools.

See: https://github.com/openwrt/luci/issues/7059

If this was merged, the follow up to OpenWrt would look something like:

```
diff --git a/package/network/services/uhttpd/files/uhttpd.init b/package/network/services/uhttpd/files/uhttpd.init
index 89ca0c6c1d..3589024bbd 100755
--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -103,6 +103,10 @@ append_ucode_prefix() {
        fi
 }
 
+append_extra_header() {
+       procd_append_param command -z "$1"
+}
+
 start_instance()
 {
        UHTTPD_CERT=""
@@ -190,6 +194,8 @@ start_instance()
                procd_append_param command -I "$path"
        done
 
+       config_list_foreach "$cfg" extra_header append_extra_header
+
        config_get https "$cfg" listen_https
        config_get UHTTPD_KEY  "$cfg" key  /etc/uhttpd.key
        config_get UHTTPD_CERT "$cfg" cert /etc/uhttpd.crt
```