### PR TITLE
proc: fix missing chunked-EOF on CGI/ucode responses

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -239,6 +239,9 @@ static void proc_handle_header_end(struct relay *r)
 
 	ustream_printf(cl->us, "\r\n");
 
+	/* Begin DATA phase so chunked-EOF will be emitted */
+	cl->state = CLIENT_STATE_DATA;
+
 	if (cl->request.method == UH_HTTP_MSG_HEAD)
 		r->skip_data = true;
 }


### PR DESCRIPTION
When serving dynamic content via CGI (or ucode) handlers without a `Content-Length` header, uHTTPd falls back to HTTP/1.1 chunked transfer encoding. At the end of the child process’s output, uHTTPd must emit the terminating zero-length chunk (`0\r\n\r\n`) to signal end-of-stream. However, due to a missing state transition in `proc_handle_header_end()`, this final chunk is never sent, and clients (e.g. curl) hang waiting for more data.

**Note:** I discovered this bug when building and running uHTTPd on Alpine Linux (i.e. against musl libc). It’s possible that OpenWrt’s build or runtime environment masks this issue, so it may not surface on OpenWrt by default.

### Reproduction

1. Start uHTTPd:
    ```
    $ uhttpd -f -p 127.0.0.1:8080 -p [::1]:80 -h /var/www -R -x /cgi-bin
    ````
1. Example CGI script (/var/www/cgi-bin/test):
    ```sh
    #!/bin/sh
    echo 'Status: 200'
    echo ''
    echo 'Hello, world!'
    exit 0
    ```
1. GET the CGI script using curl:
    ```
    $ time curl -v http://localhost/cgi-bin/test
    * Host localhost:80 was resolved.
    * IPv6: ::1
    * IPv4: 127.0.0.1
    *   Trying [::1]:80...
    * Connected to localhost (::1) port 80
    * using HTTP/1.x
    > GET /cgi-bin/test HTTP/1.1
    > Host: localhost
    > User-Agent: curl/8.13.0
    > Accept: */*
    >
    * Request completely sent off
    < HTTP/1.1 200 OK
    < Connection: Keep-Alive
    < Transfer-Encoding: chunked
    < Keep-Alive: timeout=20
    <
    Hello, world!
    * transfer closed with outstanding read data remaining
    * closing connection #0
    curl: (18) transfer closed with outstanding read data remaining
    Command exited with non-zero status 18
    real	0m 20.02s
    user	0m 0.00s
    sys	0m 0.00s
    ```

### Root cause

In `proc_handle_header_end()` (in `proc.c`), after emitting the blank line ending the HTTP headers, uHTTPd does not transition the client state from `CLIENT_STATE_HEADER` to `CLIENT_STATE_DATA`. As a result, when the child process exits, `uh_chunk_eof()` sees that `cl->state != CLIENT_STATE_DATA` and skips writing the `0\r\n\r\n` terminator.


### Fix

```diff
--- a/proc.c
+++ b/proc.c
@@ -XXX,6 +XXX,9 @@ static void proc_handle_header_end(struct relay *r)
     ustream_printf(cl->us, "\r\n");

+    /* Begin DATA phase so chunked-EOF will be emitted */
+    cl->state = CLIENT_STATE_DATA;
+
     if (cl->request.method == UH_HTTP_MSG_HEAD)
         r->skip_data = true;
 }
```

```
$ time curl -v http://localhost/cgi-bin/test
* Host localhost:80 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:80...
* Connected to localhost (::1) port 80
* using HTTP/1.x
> GET /cgi-bin/test HTTP/1.1
> Host: localhost
> User-Agent: curl/8.13.0
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 200 OK
< Connection: Keep-Alive
< Transfer-Encoding: chunked
< Keep-Alive: timeout=20
<
Hello, world!
* Connection #0 to host localhost left intact
real	0m 0.00s
user	0m 0.00s
sys	0m 0.00s
```

**Disclaimer:** I found the cause and the fix using ChatGPT, so there’s a possibility that it’s wrong, but I briefly tested it and it seems to work.