### PR TITLE
ubus: unregister ubus subscriber on HTTP client disconnect

### DIFF
--- a/ubus.c
+++ b/ubus.c
@@ -362,6 +362,14 @@ static void uh_ubus_subscription_notification_remove_cb(struct ubus_context *ctx
 	ops->request_done(cl);
 }
 
+/* Cleanup function to unregister ubus subscriber when HTTP client closes */
+static void uh_ubus_subscription_free(struct client *cl)
+{
+	struct dispatch_ubus *du = &cl->dispatch.ubus;
+	if (du->sub.obj.id)
+		ubus_unregister_subscriber(ctx, &du->sub);
+}
+
 static void uh_ubus_handle_get_subscribe(struct client *cl, const char *path)
 {
 	struct dispatch_ubus *du = &cl->dispatch.ubus;
@@ -398,6 +406,9 @@ static void uh_ubus_handle_get_subscribe(struct client *cl, const char *path)
 
 	if (conf.events_retry)
 		ops->chunk_printf(cl, "retry: %d\n", conf.events_retry);
+
+	/* Ensure cleanup on client disconnect */
+	cl->dispatch.free = uh_ubus_subscription_free;
 
 	return;
 


### PR DESCRIPTION
Fixes a potential SIGSEGV when a client disconnects from a `/ubus/subscribe/...` endpoint without unsubscribing. The ubus subscriber is now properly unregistered in a cleanup handler, preventing callbacks on freed client structures.

Fixes: #1

---

**Historical context:**
- The affected RESTful ubus functionality was originally introduced in September 2020 ([mailing list announcement](https://lists.openwrt.org/pipermail/openwrt-devel/2020-September/031396.html)).
- This bug was first reported in April 2023 (see #1), but likely existed since the initial implementation.

This fix aims to address a long-standing issue affecting ubus subscriptions over HTTP.