### PR TITLE
cgi, file: fix crash due to field_len type mismatch with libubox

### DIFF
--- a/cgi.c
+++ b/cgi.c
@@ -31,6 +31,12 @@ void uh_interpreter_add(const char *ext, const char *path)
 	in = calloc_a(sizeof(*in),
 		&new_ext, strlen(ext) + 1,
 		&new_path, strlen(path) + 1);
+	if (!in) {
+		fprintf(stderr,
+			"uhttpd: OOM while adding CGI interpreter (%s -> %s)\n",
+			ext, path);
+		return;
+	}
 
 	in->ext = strcpy(new_ext, ext);
 	in->path = strcpy(new_path, path);

--- a/file.c
+++ b/file.c
@@ -793,7 +793,7 @@ uh_free_pending_request(struct client *cl)
 	free(dr);
 }
 
-static int field_len(const char *ptr)
+static size_t field_len(const char *ptr)
 {
 	if (!ptr)
 		return 0;
@@ -821,6 +821,10 @@ uh_defer_script(struct client *cl, struct dispatch_handler *d, char *url, struct
 #undef _field
 #define _field(_name) &_##_name, field_len(pi->_name),
 		dr = calloc_a(sizeof(*dr), &_url, strlen(url) + 1, path_info_fields NULL);
+		if (!dr) {
+			uh_client_error(cl, 500, "Internal Server Error", "Out of memory");
+			return;
+		}
 
 		memcpy(&dr->pi, pi, sizeof(*pi));
 		dr->path = true;
@@ -831,6 +835,10 @@ uh_defer_script(struct client *cl, struct dispatch_handler *d, char *url, struct
 		path_info_fields
 	} else {
 		dr = calloc_a(sizeof(*dr), &_url, strlen(url) + 1, NULL);
+		if (!dr) {
+			uh_client_error(cl, 500, "Internal Server Error", "Out of memory");
+			return;
+		}
 	}
 
 	cl->dispatch.req_data = dr;


### PR DESCRIPTION
In libubox commit https://github.com/openwrt/libubox/commit/9b488010c4a74202a85ed24e01108fe069bd42e4, the type of `alloc_len` in `calloc_a` was changed to `size_t`.

Since uhttpd still defined `field_len` as returning `int`, this type mismatch caused uhttpd to crash. So change `field_len` type to `size_t` and add NULL check.

Fixes: https://github.com/openwrt/luci/issues/8629
Fixes: https://github.com/openwrt/libubox/pull/45