### PR TITLE
listen: set IP_FREEBIND so binding to a not-yet-present address works

### DIFF
--- a/listen.c
+++ b/listen.c
@@ -169,6 +169,24 @@ int uh_socket_bind(const char *host, const char *port, bool tls)
 			goto error;
 		}
 
+		/*
+		 * Allow binding to an address that is not (yet) assigned to a
+		 * local interface. Without this, starting before the network is
+		 * fully configured makes bind() fail with EADDRNOTAVAIL when a
+		 * specific listen address is used, and uhttpd never recovers.
+		 * Best effort: ignore failures so older kernels keep working.
+		 */
+#if defined(IP_FREEBIND)
+		if (p->ai_family == AF_INET &&
+		    setsockopt(sock, IPPROTO_IP, IP_FREEBIND, &yes, sizeof(yes)) < 0)
+			perror("setsockopt(IP_FREEBIND)");
+#endif
+#if defined(IPV6_FREEBIND)
+		if (p->ai_family == AF_INET6 &&
+		    setsockopt(sock, IPPROTO_IPV6, IPV6_FREEBIND, &yes, sizeof(yes)) < 0)
+			perror("setsockopt(IPV6_FREEBIND)");
+#endif
+
 		/* bind */
 		if (bind(sock, p->ai_addr, p->ai_addrlen) < 0) {
 			perror("bind()");


### PR DESCRIPTION
Fixes https://github.com/openwrt/openwrt/issues/18551

When uhttpd listens on a specific address instead of the 0.0.0.0/[::] wildcard, and it starts before the network is fully up, bind() fails with EADDRNOTAVAIL and the listener is dropped. If that was the only configured address, uhttpd prints "bind(): Address not available" followed by "No sockets bound, unable to continue" and the web UI never comes back without a manual restart. People have been hitting this on 23.05 through 25.12, especially with VLAN/management interfaces where the init script's interface-up trigger does not map the listen IP to an interface.

This sets IP_FREEBIND / IPV6_FREEBIND before bind() so the kernel lets us bind to an address that is not assigned yet. The socket starts serving the moment the address appears, so the startup race goes away without depending on the trigger heuristic. The options are best effort and #ifdef guarded, and a failed setsockopt is logged but not fatal.

Tested by building uhttpd from this branch and reproducing the issue in a Linux container:

- unpatched: binding 192.168.x.y before the address exists prints "bind(): Address not available" and exits with no sockets bound
- patched: uhttpd stays up on the absent address and serves a real HTTP GET as soon as the address is added to the interface

Verified both IPv4 (IP_FREEBIND) and IPv6 (IPV6_FREEBIND) paths, and confirmed both constants are defined under glibc and musl.

This patch was developed with AI assistance. I have reviewed, understood, and tested the change.


---
Note: this replaces #27, which GitHub auto-closed when I deleted my old fork during personal cleanup (deleting a fork silently closes its open PRs). Same commit and same state as before; nothing about the change has been modified.