### PR TITLE
file: enforce Basic Auth realms for URL-prefix handlers

### DIFF
--- a/file.c
+++ b/file.c
@@ -956,6 +956,20 @@ static char *uh_handle_alias(char *old_url)
 	return old_url;
 }
 
+static bool uh_auth_check_url(struct client *cl, const char *url)
+{
+	static const struct blobmsg_policy policy = {
+		"authorization", BLOBMSG_TYPE_STRING
+	};
+	struct blob_attr *tb;
+	const char *auth;
+
+	blobmsg_parse(&policy, 1, &tb, blob_data(cl->hdr.head), blob_len(cl->hdr.head));
+	auth = tb ? blobmsg_data(tb) : NULL;
+
+	return uh_auth_check(cl, url, auth, NULL, NULL);
+}
+
 void uh_handle_request(struct client *cl)
 {
 	struct http_request *req = &cl->request;
@@ -976,8 +990,15 @@ void uh_handle_request(struct client *cl)
 
 	req->redirect_status = 200;
 	d = dispatch_find(url, NULL);
-	if (d)
+	if (d) {
+		/* check_url handlers (lua, ucode, ubus) are dispatched here,
+		 * before the file/CGI path that performs uh_auth_check().
+		 * Enforce any matching Basic Auth realm so these handlers are
+		 * protected consistently with static files and CGI scripts. */
+		if (!uh_auth_check_url(cl, url))
+			return;
 		return uh_invoke_handler(cl, d, url, NULL);
+	}
 
 	if (__handle_file_request(cl, url, false))
 		return;


### PR DESCRIPTION
uh_handle_request() selects check_url dispatch handlers (lua, ucode and ubus) via dispatch_find(url, NULL) and invokes them through uh_invoke_handler() before reaching __handle_file_request(), which holds the only uh_auth_check() call. As a result a configured Basic Auth realm was never evaluated for those handlers: a request to a lua/ucode/ubus prefix was served without authentication, and even invalid credentials were ignored. CGI scripts are not affected because they register a check_path handler and fall through to the authenticated file path, so the same realm protected /cgi-bin/foo but silently not /api/foo.

Evaluate the matching realm against the request URL before invoking a check_url handler. uh_auth_check() already emits the 401 challenge and tears the request down on failure, so handlers stay consistent with the static file and CGI paths. Deployments without a realm covering the prefix are unaffected.

Link: https://github.com/openwrt/uhttpd/security/advisories/GHSA-5cgm-8h9x-v28c
Reported-by: @aramosf
Assisted-by: Claude:claude-opus-4-8