### PR TITLE
client: cap cumulative header count and bytes per request

### DIFF
--- a/client.c
+++ b/client.c
@@ -361,7 +361,7 @@ static void client_header_complete(struct client *cl)
 	uh_handle_request(cl);
 }
 
-static void client_parse_header(struct client *cl, char *data)
+static void client_parse_header(struct client *cl, char *data, size_t line_len)
 {
 	struct http_request *r = &cl->request;
 	char *err;
@@ -372,6 +372,18 @@ static void client_parse_header(struct client *cl, char *data)
 		uloop_timeout_cancel(&cl->timeout);
 		cl->state = CLIENT_STATE_DATA;
 		client_header_complete(cl);
+		return;
+	}
+
+	/* Cap header count and cumulative header bytes so a connection
+	 * cannot pin an unbounded amount of memory in cl->hdr; line_len
+	 * includes the CRLF stripped from the line by the caller.
+	 */
+	r->header_count++;
+	r->header_bytes += line_len;
+	if (r->header_count > UH_LIMIT_HEADER_COUNT ||
+	    r->header_bytes > UH_LIMIT_HEADER_BYTES) {
+		uh_header_error(cl, 431, "Request Header Fields Too Large");
 		return;
 	}
 
@@ -557,9 +569,9 @@ static bool client_header_cb(struct client *cl, char *buf, int len)
 	if (!newline)
 		return false;
 
-	*newline = 0;
-	client_parse_header(cl, buf);
 	line_len = newline + 2 - buf;
+	*newline = 0;
+	client_parse_header(cl, buf, line_len);
 	ustream_consume(cl->us, line_len);
 	if (cl->state == CLIENT_STATE_DATA)
 		return client_data_cb(cl, newline + 2, len - line_len);

--- a/uhttpd.h
+++ b/uhttpd.h
@@ -44,6 +44,11 @@
 
 #define UH_LIMIT_CLIENTS	64
 
+/* per-request cumulative header limits, aligned with common HTTP server
+ * defaults (Apache LimitRequestFields=100, Node.js max-header-size=16 KiB) */
+#define UH_LIMIT_HEADER_COUNT	100
+#define UH_LIMIT_HEADER_BYTES	16384
+
 #define __enum_header(_name, _val) HDR_##_name,
 #define __blobmsg_header(_name, _val) [HDR_##_name] = { .name = #_val, .type = BLOBMSG_TYPE_STRING },
 
@@ -149,6 +154,8 @@ struct http_request {
 	bool disable_chunked;
 	uint8_t transfer_chunked;
 	const struct auth_realm *realm;
+	size_t header_count;
+	size_t header_bytes;
 };
 
 enum client_state {


### PR DESCRIPTION
## Summary
- `client_parse_header()` had no cap on header count or cumulative header bytes for a single request, only a ~4096-byte per-line limit via the ustream read buffer.
- Each header line is appended to a libubox `blob_buf` (`cl->hdr`) that grows on the heap up to the ~16 MiB blob length-mask ceiling, so a single connection could pin up to ~16 MiB, and a handful of concurrent keep-alive connections streaming headers toward that cap (never sending the terminating empty line) could exhaust router memory and OOM-kill the daemon — a pre-auth, no-auth remote DoS of the web-management plane on default configurations.
- Adds `header_count`/`header_bytes` tracking to `struct http_request` (reset per request) and rejects the request with `431 Request Header Fields Too Large` once either exceeds a fixed budget (100 headers / 16 KiB cumulative — in line with Apache's `LimitRequestFields` default and Node.js's default max-header-size) before the line is appended to `cl->hdr`.

Fixes GHSA-vhx4-3p5q-m59q.

## Test plan
- [x] Built out-of-source with `-DTLS_SUPPORT=OFF` (sandbox lacks TLS dev headers), clean compile.
- [x] Legitimate requests still return `200 OK`.
- [x] A single connection streaming many small headers past 16 KiB is rejected with `431` (previously accumulated toward the ~16 MiB blob cap).
- [x] A request with >100 tiny headers (well under 16 KiB) is rejected with `431` on the count cap.
- [x] A request with 92 small headers (under both caps) succeeds normally.
- [x] 50 and 100 concurrent connections flooding unterminated headers for 8-10s: server RSS stayed flat at a few MB (vs. the advisory's reported 319 MB peak / repeated OOM-kills on unpatched code), server remained responsive to legitimate requests throughout and after.

Link: https://github.com/openwrt/uhttpd/security/advisories/GHSA-vhx4-3p5q-m59q
Reported-by: @puru1761

🤖 Generated with [Claude Code](https://claude.com/claude-code)