### PR TITLE
client: set TCP_NODELAY on accepted sockets

### DIFF
--- a/client.c
+++ b/client.c
@@ -20,6 +20,7 @@
 #include <libubox/blobmsg.h>
 #include <errno.h>
 #include <limits.h>
+#include <netinet/tcp.h>
 
 #include "uhttpd.h"
 #include "tls.h"
@@ -823,6 +824,7 @@ bool uh_accept_client(int fd, bool tls)
 	static struct client *next_client;
 	struct client *cl;
 	unsigned int sl;
+	int yes = 1;
 	int sfd;
 	static int client_id = 0;
 	struct sockaddr_in6 addr;
@@ -836,6 +838,13 @@ bool uh_accept_client(int fd, bool tls)
 	sfd = accept(fd, (struct sockaddr *) &addr, &sl);
 	if (sfd < 0)
 		return false;
+
+	/* A response is emitted as one write() per header line plus one for the
+	 * body, so with Nagle enabled the small final segment of a response on a
+	 * REUSED keep-alive connection is held back until the peer acknowledges
+	 * the previous one - which its delayed ACK timer puts ~40 ms away. Every
+	 * request after the first on a connection pays that. */
+	setsockopt(sfd, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes));
 
 	set_addr(&cl->peer_addr, &addr);
 	sl = sizeof(addr);


### PR DESCRIPTION
### Summary

uhttpd does not set `TCP_NODELAY` on accepted sockets, and it writes a response as one `write()` per header line plus one for the body. The kernel then holds the small final segment: `tcp_nagle_check()` lets a partial segment out only if `TCP_NODELAY` or `TCP_CORK` is set, or every small packet sent so far has been acknowledged (`tcp_minshall_check()`). On a keep-alive connection the previous response is still unacknowledged, so the next small body waits for the peer's delayed ACK. Every request after the first on a connection pays it.

### Reproducer

A static file and plain curl, nothing else:

```sh
printf hello > /www/tiny.txt
curl -s -o /dev/null -w 'req1 %{time_total}s\n' http://ROUTER/tiny.txt \
  --next -s -o /dev/null -w 'req2 %{time_total}s\n' http://ROUTER/tiny.txt \
  --next -s -o /dev/null -w 'req3 %{time_total}s\n' http://ROUTER/tiny.txt
for i in 1 2 3; do curl -s -o /dev/null --no-keepalive \
  -w 'fresh %{time_total}s\n' http://ROUTER/tiny.txt; done
```

|  | 25.12 (x86_64) | 24.10.7 (uhttpd 2025.07.06~7e64e8ba-r4) |
|---|--:|--:|
| req1, first on the connection | 0.4 ms | 1.0 ms |
| req2 | 41.5 ms | 42.2 ms |
| req3 | 44.6 ms | 48.8 ms |
| fresh connection each time | 0.3-0.4 ms | 0.24-0.33 ms |

strace shows uhttpd is not the slow part: it wrote response 2 within 0.4 ms of response 1, and the client's next request arrived 42.5 ms after that write. The window is the peer's delayed ACK timer, so it depends on the client. These are Linux peers.

### With the patch

Both builds come from the 25.12.5 release SDK, and the unpatched one is byte-identical to the published `uhttpd-2026.06.16~7b1bec45-r1.apk`. Same box, `http_keepalive` at its default 20:

| 3 sequential requests, one connection | req1 | req2 | req3 |
|---|--:|--:|--:|
| unpatched | 0.35 ms | 42.9 ms | 44.8 ms |
| patched | 0.32 ms | 0.087 ms | 0.075 ms |

LuCI is where it shows, since its ubus replies run a few hundred bytes and a page issues several. Warm in-place navigation over five config pages went from 540 ms to 284 ms with keep-alive untouched.

`uci set uhttpd.main.http_keepalive=0` clears the stall at http too, but keep-alive matters for TLS, and with it off six HTTPS page loads at 120 ms RTT went from 9.8 s to 29.4 s.

### Trade-off

Each of the eight writes now leaves as its own segment. Counted with tcpdump: four sequential requests to that static file go from 13 to 32 server-to-client segments, and a full LuCI page load from 752 to 1211 packets for the same payload. A few dozen extra packets per page view against 40 ms stalls.