### PR TITLE
file: enforce auth realms on plugin-dispatched URL prefixes

### DIFF
--- a/file.c
+++ b/file.c
@@ -956,6 +956,39 @@ static char *uh_handle_alias(char *old_url)
 	return old_url;
 }
 
+/*
+ * Handlers registered with .check_url (ubus, lua, ucode) are dispatched straight
+ * from uh_handle_request(), which never reaches __handle_file_request() - the only
+ * caller of uh_auth_check(). An auth realm covering such a prefix would therefore
+ * never be enforced. Evaluate the realm here, on the same URL the dispatcher
+ * matched, before handing the request to the plugin.
+ */
+static bool
+uh_dispatch_auth_check(struct client *cl, const char *url)
+{
+	static const struct blobmsg_policy hdr_policy[] = {
+		{ "authorization", BLOBMSG_TYPE_STRING },
+	};
+	struct blob_attr *tb[ARRAY_SIZE(hdr_policy)];
+	char *user, *pass;
+	const char *auth;
+
+	blobmsg_parse(hdr_policy, ARRAY_SIZE(hdr_policy), tb,
+		      blob_data(cl->hdr.head), blob_len(cl->hdr.head));
+
+	auth = tb[0] ? blobmsg_data(tb[0]) : NULL;
+
+	if (!uh_auth_check(cl, url, auth, &user, &pass))
+		return false;
+
+	if (user && pass) {
+		blobmsg_add_string(&cl->hdr, "http-auth-user", user);
+		blobmsg_add_string(&cl->hdr, "http-auth-pass", pass);
+	}
+
+	return true;
+}
+
 void uh_handle_request(struct client *cl)
 {
 	struct http_request *req = &cl->request;
@@ -976,8 +1009,12 @@ void uh_handle_request(struct client *cl)
 
 	req->redirect_status = 200;
 	d = dispatch_find(url, NULL);
-	if (d)
+	if (d) {
+		if (!uh_dispatch_auth_check(cl, url))
+			return;
+
 		return uh_invoke_handler(cl, d, url, NULL);
+	}
 
 	if (__handle_file_request(cl, url, false))
 		return;


### PR DESCRIPTION
`uh_auth_check()` is reached only from `__handle_file_request()`. `uh_handle_request()` consults `dispatch_find(url, NULL)` first and returns early when a handler matches, so requests routed to a `.check_url` handler never pass an auth check:

| handler | registration | prefix |
|---|---|---|
| ubus | `ubus.c` `uh_ubus_check_url()` | `conf.ubus_prefix` |
| lua | `lua.c` `check_lua_url()` | `conf.lua_prefix` |
| ucode | `ucode.c` `check_ucode_url()` | `conf.ucode_prefix` |

CGI registers `.check_path` instead and is matched from inside `__handle_file_request()`, *after* the auth check, which is why CGI-served paths are unaffected and the gap is easy to miss.

An operator configuring a `config httpauth` section — `uhttpd.init` `create_httpauth()` writes it to the realm file consumed by `uh_auth_check()` — for a path served by one of those handlers receives no authentication on that path, with no warning or error.

This patch evaluates the realm before dispatching, against the URL path with the query string removed. Realm matching is a prefix compare in URL space, and the plugin matchers use `uh_path_match()` on the same unmodified URL, so the two agree on what is covered.

### Testing

Compiles clean under the package's own strict flags (`-Os -Wall -Werror -Wmissing-declarations --std=gnu99`, aarch64 cortex-a53 musl, gcc 15.3.0).

I want to be straight about the limits: this is compile-verified and derived from reading the dispatch path — I have **not** stood up a uhttpd with an httpauth realm on a ubus prefix and observed the 401 appear. If you'd like that before merging, say so and I'll produce it.

### Note

`__handle_file_request()` has a second unauthenticated dispatch in the error-handler branch:

```c
if (is_error_handler) {
    d = dispatch_find(url, NULL);
    if (d) {
        uh_invoke_handler(cl, d, url, NULL);   /* no auth check */
```

I left it alone — it is reachable only through `conf.error_handler`, which is administrator-configured rather than attacker-chosen, so it is a much weaker path. It is the same shape as the bug being fixed though, so if you'd prefer both handled here I'm happy to extend the patch.
