### PR TITLE
ubus: type-check list parameters before ubus_lookup()

### DIFF
--- a/ubus.c
+++ b/ubus.c
@@ -673,8 +673,12 @@ static void uh_ubus_send_list(struct client *cl, struct blob_attr *params)
 		{
 			rem = blobmsg_data_len(dup);
 			data.verbose = true;
-			__blob_for_each_attr(cur, blobmsg_data(dup), rem)
+			__blob_for_each_attr(cur, blobmsg_data(dup), rem) {
+				if (blobmsg_type(cur) != BLOBMSG_TYPE_STRING)
+					continue;
+
 				ubus_lookup(ctx, blobmsg_data(cur), uh_ubus_list_cb, &data);
+			}
 			free(dup);
 		}
 		blobmsg_close_table(data.buf, r);


### PR DESCRIPTION
Fixes #36.

`uh_ubus_send_list()` walks the JSON-RPC `params` array with the raw
`__blob_for_each_attr()` iterator, which bounds the walk but does not check the
element type, and hands each payload to `ubus_lookup()` as a C string.

For an element that is not `BLOBMSG_TYPE_STRING` the payload carries no NUL
terminator, and `blob_memdup()` allocates exactly `blob_pad_len(attr)` bytes, so
the `strlen()` inside `blob_put_string()` reads past the end of the allocation:

```
POST /ubus
{"jsonrpc":"2.0","id":1,"method":"list","params":[16843009]}

ERROR: AddressSanitizer: heap-buffer-overflow READ of size 5
    #0 strlen
    #1 blob_put_string           libubox/blob.h:209
    #2 ubus_lookup               libubus.c:187
    #3 uh_ubus_send_list         ubus.c:677
0 bytes after 28-byte region allocated by blob_memdup
```

`16843009` is `0x01010101`, so the four payload bytes contain no zero byte and
`strlen()` cannot terminate inside them; `[true]`, `[{}]`, `[[]]` and `[1.5]`
reach it the same way. `list` is dispatched without an ACL check —
`uh_ubus_handle_request_object()` calls `uh_ubus_allowed()` only for `"call"` —
so the walk is reachable by any client that can reach the ubus prefix.

Skipping non-string elements keeps the existing behaviour for a mixed array: its
string entries still resolve.

The severity discussion is in the issue and I am not repeating it here — on
x86-64/glibc I could not turn the read into a fault or into disclosure, and
musl/32-bit remains untested.

Compiled clean against `f682cca` with the package's own flags (`-Os -Wall
-Werror -Wmissing-declarations --std=gnu99`, aarch64 musl toolchain). Not re-run
under ASan: the ASan tree the trace came from is gone, and the guard makes the
non-string path unreachable rather than changing what it does. Say the word if
you want a device-side before/after on the `list` reply.
