### PR TITLE
main: add -Z to drop privileges after binding sockets

### DIFF
--- a/main.c
+++ b/main.c
@@ -30,7 +30,9 @@
 
 #include <getopt.h>
 #include <errno.h>
+#include <grp.h>
 #include <netdb.h>
+#include <pwd.h>
 #include <signal.h>
 
 #include <libubox/usock.h>
@@ -135,6 +137,7 @@ static int usage(const char *name)
 		"	-f              Do not fork to background\n"
 		"	-c file         Configuration file, default is '/etc/httpd.conf'\n"
 		"	-p [addr:]port  Bind to specified address and port, multiple allowed\n"
+		"	-Z user         Drop to the given user after binding sockets\n"
 #ifdef HAVE_TLS
 		"	-s [addr:]port  Like -p but provide HTTPS on this port\n"
 		"	-C file         ASN.1 server certificate file\n"
@@ -275,6 +278,7 @@ int main(int argc, char **argv)
 	struct alias *alias;
 	bool nofork = false;
 	char *port;
+	const char *priv_user = NULL;
 	int opt, ch;
 	int cur_fd;
 	int bound = 0;
@@ -295,7 +299,7 @@ int main(int argc, char **argv)
 	init_defaults_pre();
 	signal(SIGPIPE, SIG_IGN);
 
-	while ((ch = getopt(argc, argv, "A:ab:C:c:Dd:E:e:fh:H:I:i:K:k:L:l:m:N:n:O:o:P:p:qQ:Rr:Ss:T:t:U:u:Xx:y:")) != -1) {
+	while ((ch = getopt(argc, argv, "A:ab:C:c:Dd:E:e:fh:H:I:i:K:k:L:l:m:N:n:O:o:P:p:qQ:Rr:Ss:T:t:U:u:Xx:y:Z:")) != -1) {
 		switch(ch) {
 #ifdef HAVE_TLS
 		case 'C':
@@ -579,6 +583,10 @@ int main(int argc, char **argv)
 			                "ignoring -%c\n", ch);
 			break;
 #endif
+		case 'Z':
+			priv_user = optarg;
+			break;
+
 		default:
 			return usage(argv[0]);
 		}
@@ -613,6 +621,23 @@ int main(int argc, char **argv)
 		    return 1;
 	}
 #endif
+
+	if (priv_user) {
+		struct passwd *pw = getpwnam(priv_user);
+
+		if (!pw) {
+			fprintf(stderr, "Error: Invalid user %s\n", priv_user);
+			return 1;
+		}
+
+		if (initgroups(priv_user, pw->pw_gid) ||
+		    setgid(pw->pw_gid) ||
+		    setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid)) {
+			fprintf(stderr, "Error: Failed to drop privileges to %s: %s\n",
+			        priv_user, strerror(errno));
+			return 1;
+		}
+	}
 
 #ifdef HAVE_LUA
 	if (lua_handler || lua_prefix) {


### PR DESCRIPTION
uhttpd itself needs root only during startup, to bind the listeners and to
read the TLS key, and then keeps it for the process lifetime. `-Z user` drops
it once startup is done; without `-Z` nothing changes. Read before the drop,
the key stays `root:root 0600`. CGI children inherit the dropped uid, so a
handler needing root needs its own fix (openwrt/cgi-io#6).

The drop is these three calls in this order, so no saved root uid and no root
supplementary group survives it, and it runs before the daemonizing fork:

    main.c, main():

        if (priv_user) {
                struct passwd *pw = getpwnam(priv_user);
                ...
                if (initgroups(priv_user, pw->pw_gid) ||
                    setgid(pw->pw_gid) ||
                    setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid)) {

It sits after `uh_tls_init()` and before the `uh_plugin_init()` calls, because
the ubus plugin connects in its init:

    ubus.c, uh_ubus_init():

        ctx = ubus_connect(conf.ubus_socket);

My understanding is that ubusd reads the peer uid from SO_PEERCRED when the
connection is accepted and exempts uid 0 from its ACLs, so a socket opened
before the drop stays a root socket for the life of the process. Connecting
afterwards is what puts the daemon's ubus access under `/usr/share/acl.d`.

This has run on an ipq807x router. `file exec` on rpcd with no session id
answered `uid=0(root)` through a ubus socket opened before the drop, and
`Permission denied` through one opened after, on a single before/after run.
Beyond that I have not exercised the daemon at the dropped uid. I used AI to
help me write this change.

openwrt/openwrt#24740 is the package side that passes `-Z`.

Is before `uh_plugin_init()` the right place, or does a lua or ucode init need
root for anything?
